### PR TITLE
DDT-525:Release emails when primary receiver & only mark newly created OperationsEvent as timestamp

### DIFF
--- a/src/main/java/org/dcsa/jit/notifications/model/MailTemplate.java
+++ b/src/main/java/org/dcsa/jit/notifications/model/MailTemplate.java
@@ -2,8 +2,10 @@ package org.dcsa.jit.notifications.model;
 
 import lombok.Data;
 import org.dcsa.core.events.model.Event;
+import org.dcsa.core.events.model.TimestampDefinition;
 import org.dcsa.core.events.model.enums.EventClassifierCode;
 import org.dcsa.core.events.model.enums.EventType;
+import org.dcsa.core.events.model.enums.PartyFunction;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
@@ -25,11 +27,16 @@ public class MailTemplate {
 
     private Set<EventType> onlyForEventType;
 
-    public boolean appliesToEvent(Event event) {
+    private Set<PartyFunction> primaryReceivers;
+
+    public boolean appliesToEvent(Event event, TimestampDefinition timestampDefinition) {
         if (!onlyForEventType.isEmpty() && !onlyForEventType.contains(event.getEventType())) {
             return false;
         }
         if (!onlyForEventClassifierCode.isEmpty() && !onlyForEventClassifierCode.contains(event.getEventClassifierCode())) {
+            return false;
+        }
+        if( !primaryReceivers.isEmpty() && (timestampDefinition == null || !primaryReceivers.contains(timestampDefinition.getPrimaryReceiver()))){
             return false;
         }
         return true;

--- a/src/main/java/org/dcsa/jit/notifications/model/MailTemplate.java
+++ b/src/main/java/org/dcsa/jit/notifications/model/MailTemplate.java
@@ -27,7 +27,7 @@ public class MailTemplate {
 
     private Set<EventType> onlyForEventType;
 
-    private Set<PartyFunction> primaryReceivers;
+    private Set<PartyFunction> onlyWhenPrimaryReceiverIs;
 
     public boolean appliesToEvent(Event event, TimestampDefinition timestampDefinition) {
         if (!onlyForEventType.isEmpty() && !onlyForEventType.contains(event.getEventType())) {
@@ -36,7 +36,7 @@ public class MailTemplate {
         if (!onlyForEventClassifierCode.isEmpty() && !onlyForEventClassifierCode.contains(event.getEventClassifierCode())) {
             return false;
         }
-        if( !primaryReceivers.isEmpty() && (timestampDefinition == null || !primaryReceivers.contains(timestampDefinition.getPrimaryReceiver()))){
+        if(!onlyWhenPrimaryReceiverIs.isEmpty() && (timestampDefinition == null || !onlyWhenPrimaryReceiverIs.contains(timestampDefinition.getPrimaryReceiver()))) {
             return false;
         }
         return true;

--- a/src/main/java/org/dcsa/jit/notifications/service/TimestampNotificationMailService.java
+++ b/src/main/java/org/dcsa/jit/notifications/service/TimestampNotificationMailService.java
@@ -1,11 +1,12 @@
 package org.dcsa.jit.notifications.service;
 
 import org.dcsa.core.events.model.Event;
+import org.dcsa.core.events.model.TimestampDefinition;
 import org.dcsa.jit.notifications.model.PendingEmailNotification;
 import reactor.core.publisher.Flux;
 
 public interface TimestampNotificationMailService {
 
 
-    Flux<PendingEmailNotification> sendEmailNotificationsForEvent(Event event);
+    Flux<PendingEmailNotification> sendEmailNotificationsForEvent(Event event,TimestampDefinition timestampDefinition);
 }

--- a/src/main/java/org/dcsa/jit/notifications/service/impl/NotificationEndpointServiceImpl.java
+++ b/src/main/java/org/dcsa/jit/notifications/service/impl/NotificationEndpointServiceImpl.java
@@ -162,7 +162,7 @@ public class NotificationEndpointServiceImpl extends ExtendedBaseServiceImpl<Not
                                                         return Mono.error(new CreateException("Cannot derive portCallPhaseTypeCode automatically from this timestamp. Please define it explicitly"));
                                                     }
                                                     return timestampDefinitionService.markOperationsEventAsTimestamp((OperationsEvent) event);
-                                                }else {
+                                                }  else {
                                                     return Mono.just(event);
                                                 }
                                             })

--- a/src/main/java/org/dcsa/jit/notifications/service/impl/TimestampNotificationMailServiceImpl.java
+++ b/src/main/java/org/dcsa/jit/notifications/service/impl/TimestampNotificationMailServiceImpl.java
@@ -135,11 +135,11 @@ public class TimestampNotificationMailServiceImpl implements TimestampNotificati
     }
 
     @Override
-    public Flux<PendingEmailNotification> sendEmailNotificationsForEvent(Event event) {
+    public Flux<PendingEmailNotification> sendEmailNotificationsForEvent(Event event, TimestampDefinition timestampDefinition) {
         return Flux.fromIterable(mailConfiguration.getTemplates().keySet())
                 .filter(templateName -> {
                     MailTemplate template = mailConfiguration.getTemplate(templateName);
-                    if (!template.appliesToEvent(event)) {
+                    if (!template.appliesToEvent(event,timestampDefinition)) {
                         return false;
                     }
                     // Except for debugging, we discard emails now without a TO address.  Under debugging, the
@@ -181,7 +181,7 @@ public class TimestampNotificationMailServiceImpl implements TimestampNotificati
             }
         }
 
-        if (!template.appliesToEvent(operationsEvent)) {
+        if (!template.appliesToEvent(operationsEvent,timestampDefinition)) {
             // Should not happen (unless config changes between storing in the DB and sending)
             log.info("Skipping mail notification (" + templateName + "); appliesToEvent rejected message: " + operationsEvent.getEventID());
             return Mono.just(operationsEvent);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -96,9 +96,6 @@ dcsa:
         onlyForEventClassifierCode:
           - EST
           - REQ
-        onlyWhenPrimaryReceiverIs:
-          - CA
-          - VSL
         subject: Response requested on timestamp from vessel {{VESSEL_NAME}}.
         body: |
           <p>Vessel {{VESSEL_NAME}} // IMO{{VESSEL_IMO_NUMBER}} registered a new {{TIMESTAMP_TYPE}}. Your response is required.</p>

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -96,7 +96,7 @@ dcsa:
         onlyForEventClassifierCode:
           - EST
           - REQ
-        primaryReceivers:
+        onlyWhenPrimaryReceiverIs:
           - CA
           - VSL
         subject: Response requested on timestamp from vessel {{VESSEL_NAME}}.

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -96,6 +96,9 @@ dcsa:
         onlyForEventClassifierCode:
           - EST
           - REQ
+        primaryReceivers:
+          - CA
+          - VSL
         subject: Response requested on timestamp from vessel {{VESSEL_NAME}}.
         body: |
           <p>Vessel {{VESSEL_NAME}} // IMO{{VESSEL_IMO_NUMBER}} registered a new {{TIMESTAMP_TYPE}}. Your response is required.</p>


### PR DESCRIPTION
- primary receivers is included as a check for whether an email should be released.
- Fixed bug where existing OperationsEvent where marked as Timestamp.